### PR TITLE
fix: org name

### DIFF
--- a/.github/workflows/invitation.yml
+++ b/.github/workflows/invitation.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Invite on label
         uses: vj-abigo/invite-on-label@v1.2
         with:
-          organization: CeruleanCodersComm
+          organization: InnateComm
           label: invite me to the organisation
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           comment: '<h1>Hey there buddy 👋</h1> <br> You have been invited to <a href="https://github.com/CeruleanCodersComm">CeruleanCodersComm</a>! 🚀 You can either accept it by going to <a href="https://github.com/CeruleanCodersComm">the organisation page</a> or checking <a href="https://github.com/settings/emails">your primary github email inbox</a>.'


### PR DESCRIPTION
The organization name was set as CeruleanCodersComm, but it is InnateComm now. Updated it to prevent issues with the automatic invitations.

## Related Issue

Closes: #33

### Describe the changes you've made

<!-- Give a clear description of what modifications you have made -->

## How has this been tested?

<!-- Describe how have you verified the changes made -->

## Checklist
<!--
Example how to mark a checkbox:-
- [x] I have performed a self-review of my own code.
-->
- [X] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [X] I have made corresponding changes to the documentation.
- [X] I have followed the code style of the project
- [ ] I have tested my code, and it works without errors

## Code of Conduct

- [X] I agree to follow this project's [Code of Conduct](https://github.com/CeruleanCodersComm/.github/blob/main/CODE_OF_CONDUCT.md)
