### PR TITLE
docs: Modify the Organisations link in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### How do I get invited to the org?
 
-- Navigate to the [issues tab](https://github.com/CeruleanCodersComm/community/issues)
+- Navigate to the [issues tab](https://github.com/InnateComm/community/issues)
   <details>
 
   <summary>👇 Screenshot</summary>
@@ -61,7 +61,7 @@
 
   </details>
 
-- Navigate to the [org page](https://github.com/CeruleanCodersComm)
+- Navigate to the [org page](https://github.com/InnateComm)
 
 - Click on the banner and you'll reach this page
   <details>
@@ -76,7 +76,7 @@
 
 ### How do I set the Organization to Public?
 
-- Navigate to our [community page](https://github.com/CeruleanCodersComm)
+- Navigate to our [community page](https://github.com/InnateComm)
 - Click on the highlighted area:
   <details>
 
@@ -144,4 +144,4 @@
 
 Thanks a lot for spending your time in helping our community grow. Thanks a lot! Keep rocking 🍻
 
-[![Contributors](https://contrib.rocks/image?repo=CeruleanCodersComm/community)](https://github.com/CeruleanCodersComm/community/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=InnateComm/community)](https://github.com/InnateComm/community/graphs/contributors)


### PR DESCRIPTION

### Describe the changes you've made

Readme file contains a lot of links which are broken or not updated with current org name.
Changed ->
`https://github.com/CeruleanCodersComm`
To
`https://github.com/InnateComm`
## How has this been tested?

<!-- Describe how have you verified the changes made -->

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] I have followed the code style of the project
- [x] I have tested my code, and it works without errors

## Additional Information


<img width="355" alt="image" src="https://user-images.githubusercontent.com/86338762/196590571-858b2589-1664-4f54-9990-931fc9c19a4c.png">

<img width="965" alt="image" src="https://user-images.githubusercontent.com/86338762/196590541-a90dcf00-81c7-449e-9a9b-9b5f0cfa574c.png">
 
## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/CeruleanCodersComm/.github/blob/main/CODE_OF_CONDUCT.md)
